### PR TITLE
Fix module crashes with the reasons described below

### DIFF
--- a/lib/restifizer-files.js
+++ b/lib/restifizer-files.js
@@ -26,7 +26,7 @@ function FileDataService(options) {
   var requiredOptions = ['dataSource', 'path', 'fileField'];
   requireOptions(this, requiredOptions);
 
-  this.provider = this.provider | 'gridfs';
+  this.provider = this.provider || 'gridfs';
   this._provider = require('../storages/' + this.provider);
 
   if (_.isFunction(this.dataSource.initialize)) {
@@ -282,9 +282,7 @@ _.extend(FileDataService.prototype, {
 
   buildConditionsAsync: function (req) {
     return _.pick(req.params, _.keys(req.params));
-  },
-
-  setProp: setProp
+  }
 });
 
 FileDataService.extend = extend;
@@ -295,6 +293,10 @@ var FileFieldController = FileDataService.extend(_.extend(CommonController, {
   supportedMethods: null,
 
   constructor: function(options) {
+
+    options = _.extend(options, {
+      dataSource: this.dataSource
+    });
     FileDataService.apply(this, arguments);
 
     _.extend(this, options);

--- a/storages/gridfs.js
+++ b/storages/gridfs.js
@@ -11,7 +11,7 @@ var
 module.exports = {
 
   initialize: function(options) {
-    this.db = options.ModelClass.db.db;
+    this.db = options.dataSource.ModelClass.db.db;
   },
 
   getFileAsync: function (fileMeta) {


### PR DESCRIPTION
- options given to storage doesn't contain dataSource reference so I think it's impossible to configure storage without any dataSource data;
- as I understand, setProp was removed unclean;
- provider  boolean condition returns wrong data;
