### PR TITLE
Add `Content-Length` attribute retrieved from GridFS

### DIFF
--- a/storages/gridfs.js
+++ b/storages/gridfs.js
@@ -21,6 +21,7 @@ module.exports = {
     return store.openAsync().then(function (db) {
       return {
         contentType: fileMeta.contentType,
+        contentLength: db.stream(true).totalBytesToRead,
         stream: db.stream(true)
       };
     });


### PR DESCRIPTION
BEFORE:

```
iMac-Eugene:~ eugene$ http -d GET http://localhost:1341/api/resource/<_id>/filefield "Authorization: Basic ZGVmYXVsdDpkZWZhdWx0" > input.zip
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: undefined
Content-Type: application/zip
Date: Tue, 29 Dec 2015 23:45:18 GMT
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block

Downloading to "<stdout>"
 /    6.66 MB     0.00 B/s
http: error: ConnectionError: HTTPConnectionPool(host='localhost', port=1341): Read timed out.
```

AFTER: 

```
iMac-Eugene:~ eugene$ http -d GET http://localhost:1341/api/resource/<_id>/filefield "Authorization: Basic ZGVmYXVsdDpkZWZhdWx0" > input.zip
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 6994017
Content-Type: application/zip
Date: Tue, 29 Dec 2015 23:49:18 GMT
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block

Downloading 6.67 MB to "<stdout>"
Done. 6.67 MB in 0.09822s (67.91 MB/s)
```
