### PR TITLE
Fill filename field for gridfs store.

### DIFF
--- a/lib/storages/gridfs.js
+++ b/lib/storages/gridfs.js
@@ -28,7 +28,10 @@ class GridFsStorage {
   }
 
   putFile(path, options) {
-    const gridStore = Bb.promisifyAll(new GridStore(this.db, new ObjectID(), 'w', options));
+    const { fileName, ...rest } = options;
+    options = rest || {};
+    const gridStore = Bb
+      .promisifyAll(new GridStore(this.db, new ObjectID(), fileName, 'w', options));
 
     return Bb
       .try(() => gridStore.openAsync())
@@ -44,13 +47,14 @@ class GridFsStorage {
 
   replaceFile(fileMeta, path, options) {
     const id = fileMeta.fileId;
+    const { fileName, ...rest } = options;
 
     return Bb
       .bind(this)
       .then(() => {
-        options = options || {};
+        options = rest || {};
         options.root = 'fs';
-        const store = Bb.promisifyAll(new GridStore(this.db, id, 'w', options));
+        const store = Bb.promisifyAll(new GridStore(this.db, id, fileName, 'w', options));
         return store.openAsync();
       })
       .then(store => store.rewindAsync())


### PR DESCRIPTION
To fill filename when creating and replacing files with GridStore, necessary to pass filename as third optional parameter. It works for both 2.2 and 3.0 versions of node.js driver.
link: http://mongodb.github.io/node-mongodb-native/3.0/api/GridStore.html

Before: when creating GridStore instance at str `31` and `53` of ` lib/storages/gridfs.js`, parametrs passed to constructor were (db, id, mode, options) . Since filename is a optional parametr, it sets `filename` field to null. Example: 
```
{
    "_id" : ObjectId("5abccf8b8c45391568592ce5"),
    "filename" : null,
    ....
    "md5" : "0cf01228ccc05aa9005809bb517ffd12"
}
```
After: if add third optional parameter `filename` corresponding field became filled with value that is passed, example:
```
 {
    "_id" : ObjectId("5ac5cad09d1c943cc87e45e0"),
    "filename" : "post_img.jpg",
    ....
    "md5" : "53c089ecfb0b8a09eca91193e271efb8"
}
``` 
In case of replace: working as expected - new instance created with new file name but existing ObjectID, after write a file `filename` has changing to according name.