### PR TITLE
Support new mime types

### DIFF
--- a/lib/file-data-service.js
+++ b/lib/file-data-service.js
@@ -3,11 +3,10 @@
 const _ = require('lodash');
 const Bb = require('bluebird');
 const HTTP_STATUSES = require('http-statuses');
-const mmm = require('mmmagic');
+const mime = require('mime-types');
 
 const utils = require('./utils');
 
-const Magic = mmm.Magic;
 const requireOptions = utils.requireOptions;
 
 class FileDataService {
@@ -140,11 +139,7 @@ class FileDataService {
         if (file) {
           scope.file = file;
           return Bb
-            .try(() => {
-              const magic = new Magic(mmm.MAGIC_MIME_TYPE);
-              Bb.promisifyAll(magic);
-              return magic.detectFileAsync(file.path);
-            })
+            .try(() => mime.lookup(file.path))
             .then((mimeType) => {
               const options = { mimeType, path: file.path };
               if (this.converter) {

--- a/lib/storages/local.js
+++ b/lib/storages/local.js
@@ -4,7 +4,7 @@ const Bb = require('bluebird');
 const fs = Bb.promisifyAll(require('fs-extra'));
 const pathM = require('path');
 const crypto = require('crypto');
-const mmm = require('mmmagic');
+const mime = require('mime-types');
 
 const utils = require('../utils');
 
@@ -22,12 +22,10 @@ class LocalStorage {
   getStream(fileMeta) {
     const fileName = this.uploadRoot + fileMeta;
 
-    const magic = Bb.promisifyAll(new mmm.Magic(mmm.MAGIC_MIME_TYPE));
-
     return Bb
       .join(
         fs.statAsync(fileName),
-        magic.detectFileAsync(fileName)
+        mime.lookup(fileName)
       )
       .spread((stats, mimeType) => {
         const fileSizeInBytes = stats.size;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "fs-extra": "^0.24.0",
     "http-statuses": "^0.2.0",
     "lodash": "^4.17.4",
-    "mmmagic": "~0.4.1",
     "mime-types": "^2.1.15",
     "restifizer-mongoose-ds": "^0.1.11",
     "restifizer-sequelize-ds": "^0.2.4"


### PR DESCRIPTION
Seems [mmmagic](https://github.com/mscdex/mmmagic) hasn't good support atm. New mime types such as `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, has been defined as `application/octet-stream`, which is incorrect. 
Decision - to use [mime-types](https://www.npmjs.com/package/mime-types) `lookup` method, which is working as expected.